### PR TITLE
fix: relax the dependency on @xstate/inspect

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@storybook/components": "^6.4.22",
     "@storybook/core-events": "^6.4.22",
     "@storybook/theming": "^6.4.22",
-    "@xstate/inspect": "^0.6",
+    "@xstate/inspect": "^0",
     "@xstate/react": "^2 || ^3",
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
     "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",


### PR DESCRIPTION
With `^0.6` the only acceptable versions are patches to 0.6 (0.6.1, 0.6.2, etc). This is because semver says that since it's a major release of version 0, there might be breaking changes even with minor releases.

Were it a different major, say 1, it would have accepted also minor releases without issues; `^1.0` would work with 1.0.1, 1.3.4, etc.

I think it would be fair to relax this requirement and leave the user of the addon to figure out the best version for them.