### PR TITLE
Fix storybook inspector height

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ storybook-static/
 build-storybook.log
 .DS_Store
 .env
+.idea

--- a/src/preset/InspectorPanel.tsx
+++ b/src/preset/InspectorPanel.tsx
@@ -29,7 +29,6 @@ const inspectorMachine =
       on: {
         SET_HEIGHT: {
           actions: "setHeight",
-          target: "#Storybook Inspector Tab",
           internal: false,
         },
         ERROR: {

--- a/src/preset/constants.ts
+++ b/src/preset/constants.ts
@@ -1,6 +1,5 @@
 export const ADDON_ID = "storybook/xstate";
 export const PANEL_ID = `${ADDON_ID}/panel`;
-export const PARAM_KEY = `xstate`;
 export const INSPECT_ID = "xstate-storybook-addon";
 
 export const EVENTS = {


### PR DESCRIPTION
# Description

* Remove the `SET_HEIGHT` event's target, it causes infinite loop when it's fired.
* Remove unused constant.

Fixes  ([#45](https://github.com/SimeonC/storybook-xstate-addon/issues/45))

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Housekeeping (non-breaking change)

# How Has This Been Tested?

1. Link the package
2. Create new component `A` with basic machine
3. Create new story for the component `A`
4. Set inspector height to `500px`
5. The visualizer loaded with the correct height


**Test Configuration**:
* Storybook: 6.5.10