### PR TITLE
Fix storybook canvas rerender

### DIFF
--- a/src/preset/withXstateInspector.ts
+++ b/src/preset/withXstateInspector.ts
@@ -1,4 +1,5 @@
 /* eslint-env browser */
+import { useState } from "react";
 import { useEffect } from "@storybook/addons";
 import { useChannel } from "@storybook/client-api";
 import { createDevTools, inspect } from "@xstate/inspect";
@@ -12,7 +13,10 @@ interface HandlerEvent extends Event {
 }
 
 export function withXstateInspector(StoryFn: (arg0: any) => any, context: any) {
-  if (context.viewMode === "docs") return StoryFn(context);
+  const [rendered, setRendered] = useState(false);
+
+  if (context.viewMode === "docs" && rendered) return StoryFn(context);
+
   try {
     if (context.parameters?.xstate) {
       Interpreter.defaultOptions.devTools = true;
@@ -59,6 +63,8 @@ export function withXstateInspector(StoryFn: (arg0: any) => any, context: any) {
     }
 
     useEffect(() => {
+      setRendered(true);
+
       function handler(event: HandlerEvent) {
         if (typeof event.data !== "object" || !("type" in event.data)) return;
         window.postMessage(event.data, "*");


### PR DESCRIPTION
# Description

* Avoid re-rendering the inspector panel when navigating between `docs` and `story` views

Fixes  ([#45](https://github.com/SimeonC/storybook-xstate-addon/issues/46))

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1. Clone the provided test repo (https://github.com/TheKnarf/storybook-xstate-test)
2. Link the package
3. Select `docs` tab
4. Go back to `story` tab
6. The Story & visualizer loaded correctly


**Test Configuration**:
* Storybook: 6.5.10